### PR TITLE
fix oscheck for puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class nslcd::params {
   $default_service_name = 'nslcd'
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       $config        = $default_config
       $package_name  = $default_package_name
       $service_name  = $default_service_name


### PR DESCRIPTION
This fixes a small bug you'll be seing if you enable the future parser or by switching to Puppet 4.