### PR TITLE
add ldap_maps hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class nslcd (
   $ldap_search_base    = $nslcd::params::ldap_search_base,
   $ldap_search_scope   = $nslcd::params::ldap_search_scope,
   $ldap_filters        = $nslcd::params::ldap_filters,
+  $ldap_maps           = $nslcd::params::ldap_maps,
   $ldap_ssl            = $nslcd::params::ldap_ssl,
   $ldap_tls_reqcert    = $nslcd::params::ldap_tls_reqcert,
   $ldap_tls_cacertfile = $nslcd::params::ldap_tls_cacertfile,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class nslcd::params {
   $ldap_search_base    = ''
   $ldap_search_scope   = 'subtree'
   $ldap_filters        = {}
+  $ldap_maps           = {}
   $ldap_ssl            = 'off'
   $ldap_tls_reqcert    = 'allow'
   $ldap_tls_cacertfile = undef

--- a/templates/nslcd.erb
+++ b/templates/nslcd.erb
@@ -38,3 +38,12 @@ scope <%= @ldap_search_scope %>
 filter <%= map %> <%= filter %>
 <% end -%>
 <% end -%>
+
+<% if @ldap_maps.length > 0 -%>
+# Custom attribute mapping
+<%   @ldap_maps.each do |map, a| -%>
+<%     a.each do |attribute, newattribute| -%>
+map <%= map %> <%= attribute %> <%= newattribute %>
+<%     end -%>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
Add ability to specify an (optional) mapping hash.  This allows for integration with various LDAP servers, such as Active Directory, that do not use (nslcd's) default attributes.

Example hiera data:
```
nslcd::ldap_maps:
  passwd:
    uid:                      sAMAccountName
    homeDirectory:            unixHomeDirectory
    gecos:                    displayName
  shadow:
    uid:                      sAMAccountName
    shadowLastChange:         pwdLastSet
```

Yields:
```
# Custom attribute mapping
map passwd uid sAMAccountName
map passwd homeDirectory unixHomeDirectory
map passwd gecos displayName
map shadow uid sAMAccountName
map shadow shadowLastChange pwdLastSet
```