### PR TITLE
Add generic ldap options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class nslcd (
   $ldap_ssl            = $nslcd::params::ldap_ssl,
   $ldap_tls_reqcert    = $nslcd::params::ldap_tls_reqcert,
   $ldap_tls_cacertfile = $nslcd::params::ldap_tls_cacertfile,
+  $ldap_options        = $nslcd::params::ldap_options,
 ) inherits nslcd::params {
 
   # Input validation

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class nslcd::params {
   $ldap_ssl            = 'off'
   $ldap_tls_reqcert    = 'allow'
   $ldap_tls_cacertfile = undef
+  $ldap_options        = {}
 
   $default_config       = '/etc/nslcd.conf'
   $default_package_name = 'nslcd'

--- a/templates/nslcd.erb
+++ b/templates/nslcd.erb
@@ -51,3 +51,4 @@ filter <%= map %> <%= filter %>
 map <%= key %> <%= value %>
 <% end -%>
 <% end -%>
+<% end -%>

--- a/templates/nslcd.erb
+++ b/templates/nslcd.erb
@@ -51,4 +51,10 @@ filter <%= map %> <%= filter %>
 map <%= key %> <%= value %>
 <% end -%>
 <% end -%>
+
+<% if @ldap_options.length > 0 -%>
+# Additional options
+<% @ldap_options.each do |name, value| -%>
+<%= name %> <%= value %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
There are several options that are not exposed as parameters. Rather than writing a parameter for every possible value, at least expose something for "key-value" pairs.

Possible to generically write hieradata:

```
ldap_options:
    nss_initgroups_ignoreusers: puppet
    idle_timelimit: 60
    bind_timelimit: 60
    tls_cacertdir: /etc/ssl
```